### PR TITLE
Click stick fix

### DIFF
--- a/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.cpp
+++ b/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.cpp
@@ -961,7 +961,6 @@ IOReturn VoodooI2CSynapticsDevice::setPowerState(unsigned long powerState, IOSer
         IOLog("%s::Going to Sleep!\n", getName());
     } else {
         if (!awake){
-            rmi_populate();
             
             awake = true;
             IOLog("%s::Woke up from Sleep!\n", getName());


### PR DESCRIPTION
I experience an issue where sometimes the trackpad will get stuck in a click/drag/highlight mode after waking from sleep. I removed "rmi_populate();" from the wake sequence on [line 964 of VoodooI2CSynapticsDevice.cpp](https://github.com/VoodooI2C/VoodooI2CSynaptics/blob/e8923aa32b15c93af48bcd5f0c1dbdc14d31b228/VoodooI2CSynaptics/VoodooI2CSynapticsDevice.cpp#L964) and it has completely resolved the issue for me. I've tested for a month and have not experienced any negative side-effects.

I have a SYNA0000 in a Dell Chromebook 13 7310 on Catalina 10.15.6. If it is suspected that this may have negative effects on other devices feel free to close the pull request and I will continue to build for myself.