### PR TITLE
Revert "Add a compatible device name"

### DIFF
--- a/VoodooI2CSynaptics/Info.plist
+++ b/VoodooI2CSynaptics/Info.plist
@@ -31,7 +31,7 @@
             <key>IOPropertyMatch</key>
             <dict>
                 <key>name</key>
-                <string>SYNA2B33 SYNA3105</string>
+                <string>SYNA2B33</string>
             </dict>
             <key>IOProviderClass</key>
             <string>VoodooI2CDeviceNub</string>


### PR DESCRIPTION
I found that this addition is not working. I had to put "SYNA3105" before "SYNA2B33" to make this kext load. 
We need to find other way to add this device name.